### PR TITLE
Add link to ACCESS Hive Forum

### DIFF
--- a/gadi/getting-started.md
+++ b/gadi/getting-started.md
@@ -6,7 +6,7 @@ The National Computing Infrastructure (NCI) hosts the supercomputer `gadi` where
 
 The [ACCESS-NRI]([https://www.access-nri.org.au) team have created some handy tutorials to help you get started on `gadi`.
 
-Click [here](https://access-hive.org.au/pr-preview/pr-857/getting_started/set_up_nci_account/) to find out how to 
+Click [here](https://access-hive.org.au/getting_started/set_up_nci_account/#change-default-project-on-gadi) to find out how to 
 - Create an account on `gadi`
 - Join relevant projects (giving you access to computational and disk storage resources)
 - Configure your 'Secure Shell Protocol' (`ssh`) so you can log into `gadi` automatically from your personal computer.
@@ -19,7 +19,7 @@ NCI have created a set of web-based graphical tools to help perform your computa
 
 ACCESS-NRI have created a quick tutorial to show you how to start an ARE session.
 
-Click [here](https://access-hive.org.au/pr-preview/pr-857/getting_started/are/) to find out how to 
+Click [here](https://access-hive.org.au/getting_started/are/) to find out how to 
 - create a Virtual Desktop Interface (VDI)
 - launch a `JuypterLab` session
 

--- a/intro.md
+++ b/intro.md
@@ -21,7 +21,7 @@ The Software Support Category on Cumulus is the *preferred contact method* as it
 - Just open a new ‘Topic’ in the Category and give as much detail about your problem/request/comment as you can. 
 - The benefit of using Cumulus means topics won’t disappear and you may find that your issue has already been asked and fixed. 
 - It also gives the chance of others in the 21st Century Weather community to give their response. 
-- There will inevitably be issues that can’t be solved within 21st Century Weather and these can be directed to the ACCESS-NRI/Hive forums if they are suitable for that platform.
+- There will inevitably be issues that can’t be solved within 21st Century Weather and these can be directed to the [ACCESS-NRI/Hive forums](https://forum.access-hive.org.au/t/access-help-and-support/908) if they are suitable for that platform.
 
 Coming Soon - Fortnightly Code Workshops. This will be an hour long session where you can bring your code in for help/ideas/review.
 


### PR DESCRIPTION
This adds a link to the existing ACCESS-Hive Forum reference in the top level intro. Specifically it links to the "Help and Support" topic which assists users with creating help requests.

Thanks!